### PR TITLE
Updated link to documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -12,7 +12,7 @@ Supports basic auth, client configuration (for ssl, etc...), proxy server suppor
 
 ## Documentation
 
-Follow this link:https://github.com/vert-x3/vertx-http-service-factory/blob/master/src/main/asciidoc/index.adoc[link].
+Follow this link:https://github.com/vert-x3/vertx-http-service-factory/src/main/asciidoc/java/index.adoc[link].
 
 == Todo
 


### PR DESCRIPTION
Just simple fix for the link in the ReadME. Getting 404 at the moment because the path is wrong.
